### PR TITLE
Rap issue 7

### DIFF
--- a/src/game/server/gamemodes/dbl.cpp
+++ b/src/game/server/gamemodes/dbl.cpp
@@ -29,7 +29,6 @@ void CGameControllerDBL::OnCharacterSpawn(class CCharacter *pChr)
 	pChr->IncreaseHealth(1);
 
 	// give default weapons
-	pChr->GiveWeapon(WEAPON_HAMMER, -1);
 	pChr->GiveWeapon(WEAPON_GUN, 10);
 }
 

--- a/src/game/server/gamemodes/dbl.cpp
+++ b/src/game/server/gamemodes/dbl.cpp
@@ -30,6 +30,9 @@ void CGameControllerDBL::OnCharacterSpawn(class CCharacter *pChr)
 
 	// give default weapons
 	pChr->GiveWeapon(WEAPON_GUN, 10);
+
+	// prevent respawn
+	pChr->GetPlayer()->m_RespawnDisabled = GetStartRespawnState();
 }
 
 int CGameControllerDBL::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)

--- a/src/game/server/gamemodes/dbl.cpp
+++ b/src/game/server/gamemodes/dbl.cpp
@@ -22,7 +22,7 @@ void CGameControllerDBL::Tick()
 	IGameController::Tick();
 }
 
-void CGameControllerDBL::OnCharacterSpawn(CCharacter *pChr)
+void CGameControllerDBL::OnCharacterSpawn(class CCharacter *pChr)
 {
 	pChr->SetMaxHealth(1);
 	pChr->SetMaxArmor(0);

--- a/src/game/server/gamemodes/dbl.cpp
+++ b/src/game/server/gamemodes/dbl.cpp
@@ -14,7 +14,7 @@ CGameControllerDBL::CGameControllerDBL(class CGameContext *pGameServer)
 {
 	m_pGameType = "DBL";
 
-	m_GameFlags = GAMEFLAG_TEAMS; // GAMEFLAG_TEAMS makes it a two-team gamemode
+	m_GameFlags = GAMEFLAG_TEAMS | GAMEFLAG_SURVIVAL; // GAMEFLAG_TEAMS makes it a two-team gamemode
 }
 
 void CGameControllerDBL::Tick()

--- a/src/game/server/gamemodes/dbl.cpp
+++ b/src/game/server/gamemodes/dbl.cpp
@@ -54,3 +54,32 @@ int CGameControllerDBL::OnCharacterDeath(class CCharacter *pVictim, class CPlaye
 	return 0;
 }
 
+void CGameControllerDBL::DoWincheckRound()
+{
+	// This function runs every server tick to check for a win condition.
+	int Count[2] = {0}; // Array for keeping track of how many players are alive on each team.
+	for(int i(0); i < MAX_CLIENTS; i++)
+	{	// 
+		if(GameServer()->m_apPlayers[i] && // Does the player at this index exist?
+		   GameServer()->m_apPlayers[i]->GetTeam() != TEAM_SPECTATORS && // Does the extant player belong to the spectator team?
+		   (!GameServer()->m_apPlayers[i]->m_RespawnDisabled || (GameServer()->m_apPlayers[i]->GetCharacter() && GameServer()->m_apPlayers[i]->GetCharacter()->IsAlive())))
+		 ++Count[GameServer()->m_apPlayers[i]->GetTeam()];	// Player exists, is not dead, and is not spectating.
+	}
+
+	if(Count[TEAM_RED]+Count[TEAM_BLUE] == 0 || (m_GameInfo.m_TimeLimit > 0 && (Server()->Tick()-m_GameStartTick) >= m_GameInfo.m_TimeLimit*Server()->TickSpeed()*60))
+	{	// If the last member of both teams dies at the same time or if the time runs out, tie.
+		++m_aTeamscore[TEAM_BLUE];
+		++m_aTeamscore[TEAM_RED];
+		EndRound();
+	}
+	else if(Count[TEAM_RED] == 0)
+	{	// Red team is completely dead, blue wins!
+		++m_aTeamscore[TEAM_BLUE];
+		EndRound();
+	}
+	else if(Count[TEAM_BLUE] == 0)
+	{	// Blue team is completely dead, red wins!
+		++m_aTeamscore[TEAM_RED];
+		EndRound();
+	}
+}

--- a/src/game/server/gamemodes/dbl.h
+++ b/src/game/server/gamemodes/dbl.h
@@ -12,6 +12,7 @@ public:
 	CGameControllerDBL(class CGameContext *pGameServer);
 	void OnCharacterSpawn(CCharacter *pChr);
 	int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon);
+	void DoWincheckRound();
 
 	virtual void Tick();
 	// add more virtual functions here if you wish


### PR DESCRIPTION
Closes Issue 7.

The DBL game mode now prevents users from respawning and ends the game when all players on a team are dead. A tie can result if the last remaining member on both teams die at the same time or if the server is using a time limit, then when the time limit is reached.

This covers requirements:
_3. The gamemode shall end when any one team has no players alive.
9. The gamemode shall award the match win to the team with players still alive at the end of the round._
and lays the ground work for requirement _5. Players shall not respawn until their killer is killed._